### PR TITLE
Uncommented Imperial Units/Types exports

### DIFF
--- a/units-defs.cabal
+++ b/units-defs.cabal
@@ -1,5 +1,5 @@
 name:           units-defs
-version:        1.0
+version:        1.0.1
 cabal-version:  >= 1.10
 synopsis:       Definitions for use with the units package
 homepage:       http://github.com/goldfirere/units-defs
@@ -23,7 +23,7 @@ description:
 source-repository this
   type:     git
   location: https://github.com/goldfirere/units-defs.git
-  tag:      v1.0
+  tag:      v1.0.1
 
 library
   build-depends:      
@@ -38,8 +38,8 @@ library
     Data.Metrology.SI.Units,
     Data.Metrology.SI.Dims,
     Data.Metrology.SI.PolyTypes
---    Data.Metrology.Imperial.Types
---    Data.Metrology.Imperial.Units
+    Data.Metrology.Imperial.Types
+    Data.Metrology.Imperial.Units
 
   default-language:   Haskell2010
 


### PR DESCRIPTION
Prevented usage of modules when installed from hackage.
Also made a small version bump. (assuming Major.Minor.Patch is being used)